### PR TITLE
fix: specify initial branch name to suppress Git hint

### DIFF
--- a/src/swiftorg.ts
+++ b/src/swiftorg.ts
@@ -51,7 +51,7 @@ export class Swiftorg {
       gitArgs.push('--recursive', '--remote')
     }
     core.debug(`Initializing submodules in "${MODULE_DIR}"`)
-    await exec('git', ['init'], {cwd: MODULE_DIR})
+    await exec('git', ['init', '-b', 'main'], {cwd: MODULE_DIR})
     core.debug(`Updating submodules in "${MODULE_DIR}" with args "${gitArgs}"`)
     await exec('git', gitArgs, {cwd: MODULE_DIR})
     const swiftorg = path.join(MODULE_DIR, 'swiftorg')


### PR DESCRIPTION
```
  hint: Using 'master' as the name for the initial branch. This default branch name
  hint: is subject to change. To configure the initial branch name to use in all
  hint: of your new repositories, which will suppress this warning, call:
  hint: 
  hint: 	git config --global init.defaultBranch <name>
  hint: 
  hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
  hint: 'development'. The just-created branch can be renamed via this command:
  hint: 
  hint: 	git branch -m <name>
  Initialized empty Git repository in /Users/runner/work/_actions/SwiftyLab/setup-swift/v1.4.1/.git/
```