### PR TITLE
fix: recursive `fs.rmdir` is deprecated

### DIFF
--- a/__tests__/swiftorg.test.ts
+++ b/__tests__/swiftorg.test.ts
@@ -5,7 +5,7 @@ import {MODULE_DIR} from '../src/const'
 
 describe('swiftorg sync validation', () => {
   const accessSpy = jest.spyOn(fs, 'access')
-  const rmdirSpy = jest.spyOn(fs, 'rmdir').mockResolvedValue()
+  const rmSpy = jest.spyOn(fs, 'rm').mockResolvedValue()
   const execSpy = jest.spyOn(exec, 'exec')
 
   it('tests latest sync', async () => {
@@ -14,7 +14,7 @@ describe('swiftorg sync validation', () => {
     fs.readdir = jest.fn().mockResolvedValue(['download'])
     const swiftorg = new Swiftorg(true)
     await swiftorg.update()
-    expect(rmdirSpy).not.toHaveBeenCalled()
+    expect(rmSpy).not.toHaveBeenCalled()
     expect(execSpy).toHaveBeenCalledTimes(2)
     const gitArgs = ['submodule', 'update', '--init', '--recursive', '--remote']
     expect(execSpy.mock.calls[1]).toStrictEqual([
@@ -30,7 +30,7 @@ describe('swiftorg sync validation', () => {
     fs.readdir = jest.fn().mockResolvedValue(['download'])
     const swiftorg = new Swiftorg(false)
     await swiftorg.update()
-    expect(rmdirSpy).not.toHaveBeenCalled()
+    expect(rmSpy).not.toHaveBeenCalled()
     expect(execSpy).toHaveBeenCalledTimes(2)
     const gitArgs = ['submodule', 'update', '--init']
     expect(execSpy.mock.calls[1]).toStrictEqual([
@@ -46,7 +46,7 @@ describe('swiftorg sync validation', () => {
     fs.readdir = jest.fn().mockResolvedValue([])
     const swiftorg = new Swiftorg(true)
     await swiftorg.update()
-    expect(rmdirSpy).toHaveBeenCalled()
+    expect(rmSpy).toHaveBeenCalled()
     expect(execSpy).toHaveBeenCalledTimes(3)
   })
 
@@ -56,7 +56,7 @@ describe('swiftorg sync validation', () => {
     fs.readdir = jest.fn().mockResolvedValue([])
     const swiftorg = new Swiftorg(false)
     await swiftorg.update()
-    expect(rmdirSpy).toHaveBeenCalled()
+    expect(rmSpy).toHaveBeenCalled()
     expect(execSpy).toHaveBeenCalledTimes(4)
   })
 
@@ -66,7 +66,7 @@ describe('swiftorg sync validation', () => {
     fs.readdir = jest.fn().mockResolvedValue([])
     const swiftorg = new Swiftorg(true)
     await swiftorg.update()
-    expect(rmdirSpy).not.toHaveBeenCalled()
+    expect(rmSpy).not.toHaveBeenCalled()
     expect(execSpy).toHaveBeenCalledTimes(3)
   })
 
@@ -76,7 +76,7 @@ describe('swiftorg sync validation', () => {
     fs.readdir = jest.fn().mockResolvedValue([])
     const swiftorg = new Swiftorg(false)
     await swiftorg.update()
-    expect(rmdirSpy).not.toHaveBeenCalled()
+    expect(rmSpy).not.toHaveBeenCalled()
     expect(execSpy).toHaveBeenCalledTimes(4)
   })
 
@@ -87,7 +87,7 @@ describe('swiftorg sync validation', () => {
     fs.readFile = jest.fn().mockResolvedValue('{}')
     const swiftorg = new Swiftorg(false)
     await swiftorg.update()
-    expect(rmdirSpy).toHaveBeenCalled()
+    expect(rmSpy).toHaveBeenCalled()
     expect(execSpy).toHaveBeenCalledTimes(3)
   })
 
@@ -98,7 +98,7 @@ describe('swiftorg sync validation', () => {
     fs.readFile = jest.fn().mockResolvedValue('{}')
     const swiftorg = new Swiftorg(false)
     await swiftorg.update()
-    expect(rmdirSpy).not.toHaveBeenCalled()
+    expect(rmSpy).not.toHaveBeenCalled()
     expect(execSpy).toHaveBeenCalledTimes(3)
   })
 })

--- a/src/swiftorg.ts
+++ b/src/swiftorg.ts
@@ -14,7 +14,7 @@ export class Swiftorg {
     try {
       await fs.access(swiftorg)
       core.debug(`Removing existing "${swiftorg}" directory`)
-      await fs.rmdir(swiftorg, {recursive: true})
+      await fs.rm(swiftorg, {recursive: true})
     } catch (error) {
       core.debug(`Failed removing "${swiftorg}" with "${error}"`)
     }


### PR DESCRIPTION
```
  (node:721) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
  (Use `node --trace-deprecation ...` to show where the warning was created)
```