### PR TITLE
feat: add support for newer Windows SDKs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -249,6 +249,9 @@ jobs:
         - os: windows-latest
           swift: '5.3'
           development: false
+        - os: windows-2019
+          swift: '5.3'
+          development: false
 
     steps:
     - name: Checkout repository

--- a/__tests__/installer/windows.test.ts
+++ b/__tests__/installer/windows.test.ts
@@ -1,10 +1,10 @@
-import * as os from 'os'
 import * as path from 'path'
 import {promises as fs} from 'fs'
 import * as core from '@actions/core'
 import * as exec from '@actions/exec'
 import * as cache from '@actions/cache'
 import * as toolCache from '@actions/tool-cache'
+import os from 'os'
 import {coerce as parseSemVer} from 'semver'
 import {WindowsToolchainInstaller} from '../../src/installer/windows'
 import {VisualStudio} from '../../src/utils/visual_studio'
@@ -55,6 +55,24 @@ describe('windows toolchain installation verification', () => {
       'Microsoft.VisualStudio.Component.VC.ATL',
       'Microsoft.VisualStudio.Component.VC.CMake.Project',
       'Microsoft.VisualStudio.Component.Windows10SDK'
+    ])
+  })
+
+  it('tests setting up on Windows 10', async () => {
+    jest.spyOn(os, 'release').mockReturnValue('10.0.17063')
+    const installer = new WindowsToolchainInstaller(toolchain)
+    expect(installer['vsRequirement'].components).toStrictEqual([
+      'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
+      'Microsoft.VisualStudio.Component.Windows10SDK.19041'
+    ])
+  })
+
+  it('tests setting up on Windows 11', async () => {
+    jest.spyOn(os, 'release').mockReturnValue('10.0.22621')
+    const installer = new WindowsToolchainInstaller(toolchain)
+    expect(installer['vsRequirement'].components).toStrictEqual([
+      'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
+      'Microsoft.VisualStudio.Component.Windows11SDK.22621'
     ])
   })
 

--- a/__tests__/installer/windows.test.ts
+++ b/__tests__/installer/windows.test.ts
@@ -31,7 +31,7 @@ describe('windows toolchain installation verification', () => {
   })
   const vsEnvs = [
     `UniversalCRTSdkDir=${path.join('C:', 'Windows Kits')}`,
-    `UCRTVersion=10.0.19041`,
+    `UCRTVersion=10.0.22000`,
     `VCToolsInstallDir=${path.join('C:', 'Visual Studio', 'Tools')}`
   ]
 

--- a/__tests__/installer/windows.test.ts
+++ b/__tests__/installer/windows.test.ts
@@ -23,15 +23,15 @@ describe('windows toolchain installation verification', () => {
   }
   const visualStudio = VisualStudio.createFromJSON({
     installationPath: path.join('C:', 'Visual Studio'),
-    installationVersion: '16',
-    catalog: {productDisplayVersion: '16'},
+    installationVersion: '17',
+    catalog: {productDisplayVersion: '17'},
     properties: {
       setupEngineFilePath: path.join('C:', 'Visual Studio', 'setup.exe')
     }
   })
   const vsEnvs = [
     `UniversalCRTSdkDir=${path.join('C:', 'Windows Kits')}`,
-    `UCRTVersion=10.0.17063`,
+    `UCRTVersion=10.0.19041`,
     `VCToolsInstallDir=${path.join('C:', 'Visual Studio', 'Tools')}`
   ]
 

--- a/__tests__/utils/visual_studio/setup.test.ts
+++ b/__tests__/utils/visual_studio/setup.test.ts
@@ -7,8 +7,8 @@ describe('visual studio setup validation', () => {
   const env = process.env
   const visualStudio = VisualStudio.createFromJSON({
     installationPath: path.join('C:', 'Visual Studio'),
-    installationVersion: '16',
-    catalog: {productDisplayVersion: '16'},
+    installationVersion: '17',
+    catalog: {productDisplayVersion: '17'},
     properties: {
       setupEngineFilePath: path.join('C:', 'Visual Studio', 'setup.exe')
     }
@@ -33,10 +33,10 @@ describe('visual studio setup validation', () => {
       stderr: ''
     })
     await expect(
-      VisualStudio.setup({version: '16', components: ['Component']})
+      VisualStudio.setup({version: '17', components: ['Component']})
     ).rejects.toMatchObject(
       new Error(
-        `Unable to find any Visual Studio installation for version: 16.`
+        `Unable to find any Visual Studio installation for version: 17.`
       )
     )
   })
@@ -51,7 +51,7 @@ describe('visual studio setup validation', () => {
       stderr: ''
     })
     await expect(
-      VisualStudio.setup({version: '16', components: ['Component']})
+      VisualStudio.setup({version: '17', components: ['Component']})
     ).resolves.toMatchObject(visualStudio)
   })
 })

--- a/__tests__/utils/visual_studio/setup.test.ts
+++ b/__tests__/utils/visual_studio/setup.test.ts
@@ -33,10 +33,10 @@ describe('visual studio setup validation', () => {
       stderr: ''
     })
     await expect(
-      VisualStudio.setup({version: '17', components: ['Component']})
+      VisualStudio.setup({version: '16', components: ['Component']})
     ).rejects.toMatchObject(
       new Error(
-        `Unable to find any Visual Studio installation for version: 17.`
+        `Unable to find any Visual Studio installation for version: 16.`
       )
     )
   })
@@ -51,7 +51,7 @@ describe('visual studio setup validation', () => {
       stderr: ''
     })
     await expect(
-      VisualStudio.setup({version: '17', components: ['Component']})
+      VisualStudio.setup({version: '16', components: ['Component']})
     ).resolves.toMatchObject(visualStudio)
   })
 })

--- a/src/installer/windows/index.ts
+++ b/src/installer/windows/index.ts
@@ -72,6 +72,7 @@ export class WindowsToolchainInstaller extends VerifyingToolchainInstaller<Windo
     }
     core.debug(`Swift installed at "${swiftPath}"`)
     const visualStudio = await VisualStudio.setup(this.vsRequirement)
+    // FIXME(stevapple): This is no longer required for Swift 5.9+
     await visualStudio.update(installation.sdkroot)
     const swiftFlags = `-sdk %SDKROOT% -I %SDKROOT%/usr/lib/swift -L %SDKROOT%/usr/lib/swift/windows`
     core.exportVariable('SWIFTFLAGS', swiftFlags)

--- a/src/installer/windows/index.ts
+++ b/src/installer/windows/index.ts
@@ -14,7 +14,9 @@ export class WindowsToolchainInstaller extends VerifyingToolchainInstaller<Windo
     const recommended = '10.0.19041'
     const current = os.release()
     const version = semver.gte(current, recommended) ? current : recommended
-    const winsdkMajor = semver.gte(version, '10.0.22000') ? semver.major(version) : 11
+    const winsdkMajor = semver.gte(version, '10.0.22000')
+      ? semver.major(version)
+      : 11
     const winsdkMinor = semver.patch(version)
     const componentsStr = core.getInput('visual-studio-components')
     const providedComponents = componentsStr ? componentsStr.split(';') : []

--- a/src/installer/windows/index.ts
+++ b/src/installer/windows/index.ts
@@ -21,7 +21,7 @@ export class WindowsToolchainInstaller extends VerifyingToolchainInstaller<Windo
     const componentsStr = core.getInput('visual-studio-components')
     const providedComponents = componentsStr ? componentsStr.split(';') : []
     return {
-      version: '17',
+      version: '16',
       components: [
         'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
         `Microsoft.VisualStudio.Component.Windows${winsdkMajor}SDK.${winsdkMinor}`,

--- a/src/installer/windows/index.ts
+++ b/src/installer/windows/index.ts
@@ -14,7 +14,7 @@ export class WindowsToolchainInstaller extends VerifyingToolchainInstaller<Windo
     const recommended = '10.0.19041'
     const current = os.release()
     const version = semver.gte(current, recommended) ? current : recommended
-    const winsdkMajor = semver.gte(version, '10.0.22000')
+    const winsdkMajor = semver.lt(version, '10.0.22000')
       ? semver.major(version)
       : 11
     const winsdkMinor = semver.patch(version)

--- a/src/installer/windows/index.ts
+++ b/src/installer/windows/index.ts
@@ -11,7 +11,7 @@ import {Installation} from './installation'
 
 export class WindowsToolchainInstaller extends VerifyingToolchainInstaller<WindowsToolchainSnapshot> {
   private get vsRequirement() {
-    const recommended = '10.0.17763'
+    const recommended = '10.0.19041'
     const current = os.release()
     const version = semver.gte(current, recommended) ? current : recommended
     const winsdkMajor = semver.gte(version, '10.0.22000') ? semver.major(version) : 11
@@ -19,7 +19,7 @@ export class WindowsToolchainInstaller extends VerifyingToolchainInstaller<Windo
     const componentsStr = core.getInput('visual-studio-components')
     const providedComponents = componentsStr ? componentsStr.split(';') : []
     return {
-      version: '16',
+      version: '17',
       components: [
         'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
         `Microsoft.VisualStudio.Component.Windows${winsdkMajor}SDK.${winsdkMinor}`,

--- a/src/installer/windows/index.ts
+++ b/src/installer/windows/index.ts
@@ -11,17 +11,18 @@ import {Installation} from './installation'
 
 export class WindowsToolchainInstaller extends VerifyingToolchainInstaller<WindowsToolchainSnapshot> {
   private get vsRequirement() {
-    const reccommended = '10.0.17763'
+    const recommended = '10.0.17763'
     const current = os.release()
-    const version = semver.gte(current, reccommended) ? current : reccommended
-    const winsdk = semver.patch(version)
+    const version = semver.gte(current, recommended) ? current : recommended
+    const winsdkMajor = semver.gte(version, '10.0.22000') ? semver.major(version) : 11
+    const winsdkMinor = semver.patch(version)
     const componentsStr = core.getInput('visual-studio-components')
     const providedComponents = componentsStr ? componentsStr.split(';') : []
     return {
       version: '16',
       components: [
         'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
-        `Microsoft.VisualStudio.Component.Windows10SDK.${winsdk}`,
+        `Microsoft.VisualStudio.Component.Windows${winsdkMajor}SDK.${winsdkMinor}`,
         ...providedComponents
       ]
     }


### PR DESCRIPTION
- Supports Windows 11 SDK correctly;
- Bumps the recommended version to Windows 10 SDK (10.0.19041);
- Build `dist/index.js`;
- Fixes typo.

This requires a SemVer minor release.