### PR TITLE
feat: allow Windows SDK version to be picked up from custom visual studio components

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -379,7 +379,8 @@ jobs:
                   uses: `${repo}@${branch}`,
                   with: {
                     'swift-version': 'latest',
-                    'check-latest': '${{ needs.ci.outputs.check_latest }}'
+                    'check-latest': '${{ needs.ci.outputs.check_latest }}',
+                    'visual-studio-components': 'Microsoft.VisualStudio.Component.Windows11SDK.22621'
                   }
                 }
               ]

--- a/__tests__/utils/visual_studio/setup.test.ts
+++ b/__tests__/utils/visual_studio/setup.test.ts
@@ -1,5 +1,6 @@
 import * as path from 'path'
 import {promises as fs} from 'fs'
+import os from 'os'
 import * as exec from '@actions/exec'
 import {VisualStudio} from '../../../src/utils/visual_studio'
 
@@ -11,7 +12,11 @@ describe('visual studio setup validation', () => {
     catalog: {productDisplayVersion: '17'},
     properties: {
       setupEngineFilePath: path.join('C:', 'Visual Studio', 'setup.exe')
-    }
+    },
+    components: [
+      'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
+      'Microsoft.VisualStudio.Component.Windows11SDK.22621'
+    ]
   })
 
   beforeEach(() => {
@@ -33,7 +38,7 @@ describe('visual studio setup validation', () => {
       stderr: ''
     })
     await expect(
-      VisualStudio.setup({version: '16', components: ['Component']})
+      VisualStudio.setup({version: '16', components: visualStudio.components})
     ).rejects.toMatchObject(
       new Error(
         `Unable to find any Visual Studio installation for version: 16.`
@@ -51,7 +56,35 @@ describe('visual studio setup validation', () => {
       stderr: ''
     })
     await expect(
-      VisualStudio.setup({version: '16', components: ['Component']})
+      VisualStudio.setup({version: '16', components: visualStudio.components})
     ).resolves.toMatchObject(visualStudio)
+  })
+
+  it('tests visual studio environment setup', async () => {
+    jest.spyOn(os, 'arch').mockReturnValue('x64')
+    const execSpy = jest.spyOn(exec, 'getExecOutput').mockResolvedValue({
+      exitCode: 0,
+      stdout: '',
+      stderr: ''
+    })
+    await visualStudio.env()
+    const arg = execSpy.mock.calls.at(0)
+    expect(arg).toBeTruthy()
+    expect(arg?.[0]).toBe('cmd')
+    expect(arg?.[1]).toStrictEqual([
+      '/k',
+      path.join(
+        visualStudio.installationPath,
+        'Common7',
+        'Tools',
+        'VsDevCmd.bat'
+      ),
+      '-arch=x64',
+      '-winsdk=10.0.22621.0',
+      '&&',
+      'set',
+      '&&',
+      'exit'
+    ])
   })
 })

--- a/src/utils/visual_studio/setup.ts
+++ b/src/utils/visual_studio/setup.ts
@@ -35,7 +35,10 @@ VisualStudio.setup = async function (requirement: VisualStudioRequirement) {
     '-version',
     requirement.version
   ])
-  const vs = VisualStudio.createFromJSON(JSON.parse(stdout)[0])
+  const vs = VisualStudio.createFromJSON({
+    ...JSON.parse(stdout)[0],
+    components: requirement.components
+  })
   if (!vs.installationPath) {
     throw new Error(
       `Unable to find any Visual Studio installation for version: ${requirement.version}.`

--- a/src/utils/visual_studio/update.ts
+++ b/src/utils/visual_studio/update.ts
@@ -6,25 +6,18 @@ import {VisualStudio} from './base'
 declare module './base' {
   // eslint-disable-next-line no-shadow
   export interface VisualStudio {
-    update(sdkroot: string, copyModules: boolean): Promise<void>
+    update(sdkroot: string): Promise<void>
   }
 }
 
 /// Update swift version based additional support files setup
-VisualStudio.prototype.update = async function (
-  sdkroot: string,
-  copyModules: boolean
-) {
+VisualStudio.prototype.update = async function (sdkroot: string) {
   const vsEnv = await this.env()
   for (const property in vsEnv) {
     if (vsEnv[property] === process.env[property]) {
       continue
     }
     core.exportVariable(property, vsEnv[property])
-  }
-
-  if (!copyModules) {
-    return
   }
   const universalCRTSdkDir = vsEnv.UniversalCRTSdkDir
   const uCRTVersion = vsEnv.UCRTVersion


### PR DESCRIPTION
fix build errors with Windows SDK 10.0.26100.0

https://forums.swift.org/t/swiftpm-plugin-doesnt-work-with-the-latest-visual-studio-version/78183/14